### PR TITLE
Added hover ability to some of the marker dots.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
   </header>
   <div class="row">
     <div class="three columns main-sidebar">
-      <nav>
+      <nav class="sidebar-nav">
         {% for page in site.pages %}
           {% if page.title %}
           <span class="marker-dot-nav-right hide-big"></span><a class="nav-page-link" href="{{ page.url | prepend: site.baseurl }}"><span class="nav-link-text">{{ page.title }}</span><span class="marker-dot-left"></span></a>

--- a/css/site.css
+++ b/css/site.css
@@ -40,10 +40,13 @@ body {
 	margin-top: 10px;
 	display: block;
 	font-family: 'Dancing Script', cursive;
-	font-size: 60pt;
-	height: 80px;
+	font-size: 50pt;
+	height: 60px;
 	float: left;
 	margin-left: 30px;
+	color: #585858;
+}
+.site-title:hover {
 	color: black;
 }
 
@@ -113,12 +116,15 @@ body {
 	margin-left: 4%;
 }
 .site-title .marker-dot-right {
-	margin-top: 40px;
+	margin-top: 30px;
 	height: 15px;
 	width: 15px;
 	margin-left: -38px;
 	background-color: #585858;
 
+}
+.site-title:hover .marker-dot-right {
+	background-color: white;
 }
 
 .nav-page-link {

--- a/css/site.css
+++ b/css/site.css
@@ -134,9 +134,27 @@ body {
 	padding: 30px;
 }
 
+.blag-link {
+	text-decoration: none;
+	color: #585858;
+}
+
+.blag-link:hover {
+	text-decoration: none;
+	color: black;
+}
+
+.blag-link:hover .marker-dot-right {
+	background-color: #585858;
+}
+
 .nav-page-link:hover {
 	text-decoration: underline;
 	color: black;
+}
+
+.nav-page-link:hover .marker-dot-left {
+	background-color: #585858;
 }
 
 .posts {
@@ -155,6 +173,10 @@ body {
 	border-radius: 7px;
 	margin-left: -34px;
 	background-color: #585858;
+}
+
+.posts .post-link:hover .marker-dot-right {
+	background-color: white;
 }
 
 .posts .post-link:hover {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
 
 <br>
 
-<h3><span class="marker-dot-right"></span>Recent Posts</h3>
+<a href="/blag/" class="blag-link"><h3><span class="marker-dot-right"></span>Recent Posts</h3></a>
 <ul class="posts">
   {% for post in site.posts limit:10 %}
     <li>


### PR DESCRIPTION
I think this would look pretty neat. I added a hover over change to some of the marker dots along the left side.  It's not particularly obvious in those screenshots since they don't show the cursor, but when you hover over the links there, the dot changes to the opposite of it's current color.
![screen shot 2015-10-01 at 10 11 49 pm](https://cloud.githubusercontent.com/assets/1504069/10238745/76651766-6889-11e5-9fa0-56ccdc0a8fc3.png)
![screen shot 2015-10-01 at 10 11 36 pm](https://cloud.githubusercontent.com/assets/1504069/10238747/7d508fba-6889-11e5-8294-d5be4fb2ffe1.png)

